### PR TITLE
Android Fix - Stop Multiple App Instances Launching

### DIFF
--- a/android/src/main/java/com/meedan/ShareMenuModule.java
+++ b/android/src/main/java/com/meedan/ShareMenuModule.java
@@ -93,8 +93,21 @@ public class ShareMenuModule extends ReactContextBaseJavaModule implements Activ
       return;
     }
 
-    Intent intent = currentActivity.getIntent();
+    //if this isn't the roor activity then make sure it is
+    if (!currentActivity.isTaskRoot()) {
+      Intent newIntent = new Intent(currentActivity.getIntent());
+      newIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+      currentActivity.startActivity(newIntent);
 
+      ReadableMap shared = extractShared(newIntent);
+      successCallback.invoke(shared);
+      clearSharedText();
+      currentActivity.finish();
+      return;
+    }
+
+    Intent intent = currentActivity.getIntent();
+    
     ReadableMap shared = extractShared(intent);
     successCallback.invoke(shared);
     clearSharedText();


### PR DESCRIPTION
On Android I've noticed that some apps still launch a new instance of the app being shared to (Google Files is a good example). 

This fix will check the currentActivity to see if it is the root and if not will repackage the intent, do the share work and close the 'bad' intent. 

The component then picks things up via `onNewIntent` 